### PR TITLE
CSS group 'all' and 'false' should be considered as the same

### DIFF
--- a/class.minqueue.php
+++ b/class.minqueue.php
@@ -571,7 +571,6 @@ class MinQueue_Styles extends MinQueue {
 		$this->file_extension = '.css';
 
 		// Stylesheets with empty media arg should be considered 'all'
-		// @todo, not sure I like doing it this way.
 		foreach ( $queue as $handle )
 			if ( isset( $this->class->registered[$handle] ) && empty( $this->class->registered[$handle]->args ) )
 				$this->class->registered[$handle]->args = 'all';


### PR DESCRIPTION
Default WP CSS has group 'false' or 0, which is different from not passing a group when enqueuing a script - as this will default to 'all'

This causes the files to be proccessed separately. So i am just setting all empty 'args' to 'all'

This is a bit quick & dirty really, so i'll have a think about it some more.
