### PR TITLE
Handle footer scripts on footer action not head

### DIFF
--- a/class.minqueue.php
+++ b/class.minqueue.php
@@ -531,6 +531,13 @@ class MinQueue_Scripts extends MinQueue {
 
 		$this->process_queue = parent::get_process_queue();
 
+		// Wait to minify footer scripts until wp_footer (& vice versa)
+		if ( did_action( 'wp_footer' ) ) {
+			unset( $this->process_queue[0] );
+		} else {
+			unset( $this->process_queue[1] );
+		}
+
 		// Get localized script data.
 		foreach( $this->process_queue as $group => $script_handles )
 			foreach( $script_handles as $handle )

--- a/plugin.php
+++ b/plugin.php
@@ -53,7 +53,9 @@ function minqueue_init () {
 
 	// Run the minifier
 	add_action( 'wp_print_scripts', 'minqueue_scripts', 999 );
+	add_action( 'wp_footer', 'minqueue_scripts' );
 	add_action( 'wp_print_styles', 'minqueue_styles', 999 );
+	
 
 	// Load the admin - unless settings are not defined.
 	if ( ! defined( 'MINQUEUE_OPTIONS' ) )


### PR DESCRIPTION
Used to minifiy all on print_scripts. This required that all script enqueuing was done before this point. Footer scripts however can be enqueued later. 

This caused an issue that you could not minify footer scripts together if one was enqueued before print_scripts and one after

Really... we should minify header scripts in head, and footer scripts in the footer. This way we can enqueue scripts later.

Calls minify on both actions, and removes the unrequired queue from proccess queues before minifying
