### PR TITLE
turn display tool on --

### DIFF
--- a/minqueue-helper-tool.php
+++ b/minqueue-helper-tool.php
@@ -240,7 +240,7 @@ function minqueue_helper_script() {
 				if ( ! self.display )
 					return;
 				
-				self.display.style.display = 'none';
+				self.display.style.display = 'block';
 				self.insertButton();
 				self.button.addEventListener( 'click', function(e) { 
 					self.toggleDisplay.call( self, e, this ) 


### PR DESCRIPTION
before this change, the helper-tool was set to display:none, even if in admin mode. Now it functions properly again.
