### PR TITLE
Add a filter so that you can hide admin notification

### DIFF
--- a/class.minqueue-admin.php
+++ b/class.minqueue-admin.php
@@ -321,7 +321,7 @@ class MinQueue_Admin {
 
 		$current_screen = get_current_screen();
 
-		if ( isset( $this->options['helper'] ) && $this->options['helper'] === true )
+		if ( isset( $this->options['helper'] ) && $this->options['helper'] === true && !apply_filters('minqueue_disable_helper_notice', false))
 			$this->admin_notices->add_notice( 'MinQueue helper is currently active', true );
 
 


### PR DESCRIPTION
The admin notification "MinQueue helper is currently active" can be pretty annoying.
I propose we add a filter to let theme authors and plugin developers remove this notice from the admin dashboard.

Here is how you would hide the notification with the proposed change, from a plugin or theme:

``` php
add_filter('minqueue_disable_helper_notice', function($var) {
    return true;
});
```
