### PR TITLE
Allow filtering of base URL

### DIFF
--- a/class.minqueue.php
+++ b/class.minqueue.php
@@ -357,11 +357,14 @@ abstract class MinQueue {
 		// Strip query args.
 		$src = strtok( $src, '?' );
 
+		// Allow filtering of base URL
+		$base_url = apply_filters( 'minqueue_assets_base_url', home_url() );
+
 		// Don't handle remote urls.
-		if ( 0 !== strpos( $src, home_url() ) )
+		if ( 0 !== strpos( $src, $base_url ) )
 			return false;
 
-		$this->asset_paths[ $handle ] = str_replace( home_url(), '', esc_url( $src ) );
+		$this->asset_paths[ $handle ] = str_replace( $base_url, '', esc_url( $src ) );
 
 		return $this->asset_paths[ $handle ];
 


### PR DESCRIPTION
When using a CDN the assets of 'local' files might already been changed to CDN and therefor will not match home_url(). This filters allows to set the CDN URL so these assets are still minified and concatenated.

Tested with Amazon Cloudfront.